### PR TITLE
B/attrupdate

### DIFF
--- a/pynio/properties.py
+++ b/pynio/properties.py
@@ -238,8 +238,7 @@ class TypedDict(AttrDict):
         if hasattr(actual, '__set__'):
             actual.__set__(None, value)
             return
-        curval = getattr(self, attr)
-        value = self._convert_value(value, curval)
+        value = self._convert_value(value, actual)
         AttrDict.__setattr__(self, attr, value, keyonly)
 
     def __set__(self, obj, value):

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -73,7 +73,10 @@ class TestTypedDict(unittest.TestCase):
     def test_set_update(self):
         '''Makes sure that object can set values like "update" that are
         also attributes (through item assignment)'''
-        attrdict = TypedDict(mydict)
+        udict = deepcopy(mydict)
+        udict['update'] = 'start'
+        attrdict = TypedDict(udict)
+        self.assertEqual(attrdict['update'], 'start')
         attrdict['update'] = 'hi'
         self.assertNotEqual(attrdict.update, 'hi')
         self.assertEqual(attrdict['update'], 'hi')

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -38,6 +38,14 @@ class TestAttrDict(unittest.TestCase):
         attr.enum = 0
         assert attr.enum == 'a'
 
+    def test_set_update(self):
+        '''Makes sure that object can set values like "update" that are
+        also attributes (through item assignment)'''
+        attrdict = AttrDict(mydict)
+        attrdict['update'] = 'hi'
+        self.assertNotEqual(attrdict.update, attrdict['update'])
+        self.assertEqual(attrdict['update'], 'hi')
+
 # class TestSolid(unittest.TestCase):
 #     def test_basic(self):
 #         solid = SolidDict(mydict)
@@ -61,6 +69,19 @@ class TestTypedDict(unittest.TestCase):
         # import ipdb; ipdb.set_trace()
         convert = TypedDict(mydict)
         self.assertRaises(ValueError, setattr, convert, 'c', 'hello')
+
+    def test_set_update(self):
+        '''Makes sure that object can set values like "update" that are
+        also attributes (through item assignment)'''
+        attrdict = TypedDict(mydict)
+        attrdict['update'] = 'hi'
+        self.assertNotEqual(attrdict.update, 'hi')
+        self.assertEqual(attrdict['update'], 'hi')
+        attrdict.update({
+            'update': 'hello'
+        })
+        self.assertNotEqual(attrdict.update, 'hello')
+        self.assertEqual(attrdict['update'], 'hello')
 
     def test_readonly(self):
         frozen = TypedDict(mydict)


### PR DESCRIPTION
there was an error when setting items like "update" -- which are attributes, but the setitem getitem should go around that fact.

The error was slightly sloppy coding. The `actual` value is now used, which did things correctly in the first place.
