### PR TITLE
F/copy

### DIFF
--- a/pynio/block.py
+++ b/pynio/block.py
@@ -108,17 +108,6 @@ class Block(object):
         self._instance.blocks.pop(self._name)
         self._instance = None  # make sure it isn't used anymore
 
-    def copy(self, name, instance=None):
-        '''return a copy of self, but with a new name and not tied to
-        any instance'''
-        if not name:
-            raise ValueError(name)
-        out = deepcopy(self)
-        out._instance = instance
-        out._name = name
-        out.config['name'] = name
-        return out
-
     def in_use(self):
         '''Return a list of services that use this block.'''
         if not self._instance:

--- a/pynio/block.py
+++ b/pynio/block.py
@@ -128,4 +128,3 @@ class Block(object):
                 self._instance.services.values()
                 if next((True for b in service.blocks if b.name == name), False)
                 ]
-

--- a/pynio/instance.py
+++ b/pynio/instance.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from pynio.rest import REST
 from pynio.block import Block
 from pynio.service import Service
@@ -103,7 +104,7 @@ class Instance(REST):
         '''Copy block from another instance to self.'''
         if not overwrite and block.name in self.blocks:
             raise ValueError
-        return self.add_block(block.copy(block.name))
+        return self.add_block(deepcopy(block))
 
     def copy_service(self, service, overwrite=False):
         '''Copy service from another instance to self.'''
@@ -121,5 +122,5 @@ class Instance(REST):
                     "Some blocks from service {} already exist: {}".
                     format(service.name, intersect))
         out_blocks = [self.copy_block(b, True) for b in blocks]
-        out_service = self.add_service(service.copy(service.name))
+        out_service = self.add_service(deepcopy(service))
         return out_service, out_blocks

--- a/pynio/service.py
+++ b/pynio/service.py
@@ -155,3 +155,13 @@ class Service(object):
     @property
     def pid(self):
         return self._status()['pid']
+
+    def copy(self, name):
+        '''Return a copy of self
+        The copy will have a new name and not be tied to any instance
+        '''
+        out = deepcopy(self)
+        out._instance = None
+        out._name = name
+        out.config['name'] = name
+        return out

--- a/pynio/service.py
+++ b/pynio/service.py
@@ -155,13 +155,3 @@ class Service(object):
     @property
     def pid(self):
         return self._status()['pid']
-
-    def copy(self, name):
-        '''Return a copy of self
-        The copy will have a new name and not be tied to any instance
-        '''
-        out = deepcopy(self)
-        out._instance = None
-        out._name = name
-        out.config['name'] = name
-        return out

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -29,23 +29,6 @@ class TestBlock(unittest.TestCase):
                                 'type': 'type',
                                 'value': 0})
 
-    def test_copy(self):
-        b = Block('name', 'type', {'key': 'value'})
-        bcopy = b.copy('newname')
-        self.assertDictEqual({
-            'name': 'newname',
-            'type': 'type',
-            'key': 'value'
-        }, bcopy.config)
-        self.assertDictEqual({
-            'name': 'name',
-            'type': 'type',
-            'key': 'value'
-        }, b.config)
-
-        with self.assertRaises(ValueError):
-            b.copy('')
-
     def test_save_with_no_instance(self):
         b = Block('name', 'type')
         b._config = {'key': 'val'}

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -78,3 +78,75 @@ class TestInstance(unittest.TestCase):
         self.assertIsInstance(service, Service)
         self.assertIn(service.name, instance.services)
         self.assertIn(service, instance.services.values())
+
+    def test_copy_block(self):
+        in1 = mock_instance()
+        in2 = mock_instance()
+
+        b1 = in1.create_block('name', 'type')
+        b2 = in2.copy_block(b1)
+        self.assertIsNot(b1, b2)
+        self.assertIsNot(b1._instance, b2._instance)
+        self.assertDictEqual(b1.json(), b2.json())
+
+        # cannot overwrite
+        with self.assertRaises(ValueError):
+            in1.copy_block(b2)
+
+        # unless specified
+        in1.copy_block(b2, True)
+
+    def test_copy_service(self):
+        in1 = mock_instance()
+        in2 = mock_instance()
+
+        s1 = in1.create_service('ser')
+        b1 = s1.create_block('b1', 'type')
+        s2, (b2,) = in2.copy_service(s1)
+
+        # test block
+        self.assertIsNot(b1, b2)
+        self.assertIsNot(b1._instance, b2._instance)
+        self.assertDictEqual(b1.json(), b2.json())
+
+        # test service
+        self.assertIsNot(s1, s2)
+        self.assertIsNot(s1._instance, s2._instance)
+        self.assertDictEqual(s1.config, s2.config)
+
+    def test_copy_service_blocks(self):
+        in1 = mock_instance()
+        in2 = mock_instance()
+
+        s1 = in1.create_service('ser')
+        b1 = s1.create_block('b1', 'type')
+        s2, (b2,) = in2.copy_service(s1)
+        s3 = in1.create_service('ser3')
+        b3 = s3.create_block('b3', 'type')
+        s3.connect(b1, b3)
+
+        # cannot copy if any blocks are the same
+        with self.assertRaises(ValueError):
+            in2.copy_service(s3)
+
+        # make sure nothing was written
+        self.assertNotIn(b3.name, in2.blocks)
+        self.assertNotIn(s3.name, in2.services)
+
+        # unless overwritten
+        b1.config.value = 42
+        self.assertNotEqual(b1.config.value, b2.config.value)
+        s4, (b4, b5) = in2.copy_service(s3, True)
+        self.assertEqual(b1.config.value, b2.config.value)
+
+        # test blocks
+        s4_b1 = s4.blocks['b1']
+        self.assertEqual(s4_b1, b2.name)
+        self.assertIsNot(s4_b1, b2)  # the object has been replaced
+        self.assertIsNot(s4_b1._instance, b2._instance)
+        self.assertNotEqual(s4_b1.config.value, b2.config.value)
+
+        # test service
+        self.assertIsNot(s1, s2)
+        self.assertIsNot(s1._instance, s2._instance)
+        self.assertDictEqual(s1.config, s2.config)

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -91,17 +91,17 @@ class TestInstance(unittest.TestCase):
         in2 = mock_instance()
 
         b1 = in1.create_block('name', 'type')
-        b2 = in2.copy_block(b1)
+        b2 = in2.add_block(b1)
         self.assertIsNot(b1, b2)
         self.assertIsNot(b1._instance, b2._instance)
         self.assertDictEqual(b1.json(), b2.json())
 
         # cannot overwrite
         with self.assertRaises(ValueError):
-            in1.copy_block(b2)
+            in1.add_block(b2)
 
         # unless specified
-        in1.copy_block(b2, True)
+        in1.add_block(b2, True)
 
     def test_copy_service(self):
         in1 = mock_instance()
@@ -109,7 +109,8 @@ class TestInstance(unittest.TestCase):
 
         s1 = in1.create_service('ser')
         b1 = s1.create_block('b1', 'type')
-        s2, (b2,) = in2.copy_service(s1)
+        s2 = in2.add_service(s1, blocks=True)
+        b2 = s2.blocks[0]
 
         # test block
         self.assertIsNot(b1, b2)
@@ -128,14 +129,15 @@ class TestInstance(unittest.TestCase):
 
         s1 = in1.create_service('ser')
         b1 = s1.create_block('b1', 'type')
-        s2, (b2,) = in2.copy_service(s1)
+        s2 = in2.add_service(s1, blocks=True)
+        b2, = s2.blocks
         s3 = in1.create_service('ser3')
         b3 = s3.create_block('b3', 'type')
         s3.connect(b1, b3)
 
         # cannot copy if any blocks are the same
         with self.assertRaises(ValueError):
-            in2.copy_service(s3)
+            in2.add_service(s3, blocks=True)
 
         # make sure nothing was written
         self.assertNotIn(b3.name, in2.blocks)
@@ -144,7 +146,8 @@ class TestInstance(unittest.TestCase):
         # unless overwritten
         b1.config.value = 42
         self.assertNotEqual(b1.config.value, b2.config.value)
-        s4, (b4, b5) = in2.copy_service(s3, True)
+        s4 = in2.add_service(s3, overwrite=True, blocks=True)
+        b4, b5 = s4.blocks
         self.assertEqual(in2.blocks['b1'].config.value, 42)
 
         # test blocks

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -155,3 +155,13 @@ class TestService(unittest.TestCase):
         self.assertListEqual(execution, [
             {'name': 'two', 'receivers': []}
         ])
+
+    def test_copy(self):
+        instance = mock_instance()
+        s = instance.create_service('name')
+        copy = s.copy('newname')
+        self.assertIs(copy._instance, None)
+        self.assertIs(s._instance, instance)
+        self.assertNotEqual(copy.config.pop('name'), s.config.pop('name'))
+        # other than the names, they are equal
+        self.assertDictEqual(copy.config, s.config)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -72,8 +72,8 @@ class TestService(unittest.TestCase):
         blk = s.create_block('one', 'type')
         with self.assertRaises(TypeError):
             s.blocks
-        instance.add_service(s)
-        instance.add_block(blk)
+        s = instance.add_service(s)
+        blk = instance.add_block(blk)
         self.assertIn(blk, s.blocks)
         self.assertNotIn(instance.create_block('two', 'type'), s.blocks)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -155,13 +155,3 @@ class TestService(unittest.TestCase):
         self.assertListEqual(execution, [
             {'name': 'two', 'receivers': []}
         ])
-
-    def test_copy(self):
-        instance = mock_instance()
-        s = instance.create_service('name')
-        copy = s.copy('newname')
-        self.assertIs(copy._instance, None)
-        self.assertIs(s._instance, instance)
-        self.assertNotEqual(copy.config.pop('name'), s.config.pop('name'))
-        # other than the names, they are equal
-        self.assertDictEqual(copy.config, s.config)


### PR DESCRIPTION
- Adds a copy methods to copy a service or block from one instance to another
- copy methods have overwrite checking to ensure that accidental overwrite doesn't occur
- added unit tests to test new methods.
- `Service.copy` had to be added to facilitate copying.
