### PR TITLE
better string formatting of blocks and services

### DIFF
--- a/pynio/block.py
+++ b/pynio/block.py
@@ -132,4 +132,5 @@ class Block(object):
 
     def __str__(self):
         config = '\n  '.join(pprint.pformat(self.config).split('\n'))
-        return "Block {} config:\n  ".format(self.name) + config + '\n'
+        return ("Block({}, {}).config:{{\n  ".format(self.name, self.type) +
+                                        config + '\n}\n')

--- a/pynio/block.py
+++ b/pynio/block.py
@@ -1,3 +1,4 @@
+import pprint
 from copy import deepcopy
 
 from .properties import load_block
@@ -129,3 +130,6 @@ class Block(object):
                 if next((True for b in service.blocks if b.name == name), False)
                 ]
 
+    def __str__(self):
+        config = '\n  '.join(pprint.pformat(self.config).split('\n'))
+        return "Block {} config:\n  ".format(self.name) + config + '\n'

--- a/pynio/service.py
+++ b/pynio/service.py
@@ -162,7 +162,7 @@ class Service(object):
         execution = sorted(self.config.get('execution', []),
                            key=lambda i: len(i['receivers']),
                            reverse=True)
-        name_fmat = '{} --> ({})'.format
+        name_fmat = '{} --> {}'.format
         outstr = []
         outstr = [name_fmat(i['name'], ', '.join(i['receivers'])) for i in
                    execution]

--- a/pynio/service.py
+++ b/pynio/service.py
@@ -1,3 +1,4 @@
+from operator import itemgetter
 from copy import deepcopy
 from .block import Block
 
@@ -155,3 +156,15 @@ class Service(object):
     @property
     def pid(self):
         return self._status()['pid']
+
+    def __str__(self):
+        # get connections, ones with most connections first
+        execution = sorted(self.config.get('execution', []),
+                           key=lambda i: len(i['receivers']),
+                           reverse=True)
+        name_fmat = '{} --> ({})'.format
+        outstr = []
+        outstr = [name_fmat(i['name'], ', '.join(i['receivers'])) for i in
+                   execution]
+        return ('Service {} Connections:\n  '.format(self.name) +
+                '\n  '.join(outstr) + '\n')

--- a/pynio/service.py
+++ b/pynio/service.py
@@ -166,5 +166,5 @@ class Service(object):
         outstr = []
         outstr = [name_fmat(i['name'], ', '.join(i['receivers'])) for i in
                    execution]
-        return ('Service {} Connections:\n  '.format(self.name) +
-                '\n  '.join(outstr) + '\n')
+        return ('Service({}).connections:{{\n  '.format(self.name) +
+                '\n  '.join(outstr) + '\n}\n')

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -116,6 +116,7 @@ class TestBlock(unittest.TestCase):
             b = Block(btype, btype)
             b._load_template(btype, template, instance)
             blocks_types[btype] = b
+            str(b)  # verify no error is raised
 
         blocks = {}
         for bname, config in BlocksConfigsAll.items():
@@ -124,6 +125,7 @@ class TestBlock(unittest.TestCase):
             b = deepcopy(blocks_types[btype])
             b.config = config
             blocks[bname] = b
+            str(b)  # verify no error is raised
 
         droplog = instance.droplog
         self.assertEqual(droplog.call_count, 2)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -155,3 +155,15 @@ class TestService(unittest.TestCase):
         self.assertListEqual(execution, [
             {'name': 'two', 'receivers': []}
         ])
+
+    def test_str(self):
+        ins = mock_instance()
+        s = ins.create_service('name')
+        b1 = s.create_block('b1', 'type')
+        b2 = s.create_block('b2', 'type')
+        b3 = s.create_block('b3', 'type')
+        s.create_block('b4', 'type')
+        s.connect(b1, b2)
+        s.connect(b1, b3)
+        s.connect(b2, b3)
+        str(s)  # verify no error is raised


### PR DESCRIPTION
- it is standard in every library to provide solid string methods to provide good visualization at the command line
- when people are first learning the library, they will be using the command line. It is extremely helpful for them to be able to see the important parts as they work with them and learn them.
- this first attempt prints out:
  - blocks by their configuration
  - services by their connections
- this will allow debugging that the user does to happen much more easily and cleanly.

Example Output:

**Service**

```
Service(test).connections:{
  sim --> sim2, sim3, sim4
  sim2 --> 
}
```

**Block**

```
Block(sim, Simulator).config:{
  {'attributes': [{'name': 'sim', 'value': {'end': 1, 'start': 0, 'step': 1}}],
   'count_total': {'count_total': -1, 'reset_interval': -1},
   'interval': {'days': 0, 'microseconds': 0, 'seconds': 1},
   'log_level': 'ERROR',
   'name': 'sim',
   'signal_count': 1,
   'signal_type': 'nio.common.signal.base.Signal',
   'type': 'Simulator'}
}
```
